### PR TITLE
Use getDestination instead of getEntryPoint

### DIFF
--- a/src/main/groovy/com/github/maiflai/ScalaTestAction.groovy
+++ b/src/main/groovy/com/github/maiflai/ScalaTestAction.groovy
@@ -37,12 +37,9 @@ class ScalaTestAction implements Action<Test> {
         }
         if (t.reports.getHtml().isEnabled()){
             args.add('-h')
-            def point = t.reports.getHtml().getEntryPoint()
-            if (point.isDirectory()){
-                args.add(point.getAbsolutePath())
-            } else {
-                args.add(point.getParent())
-            }
+             def dest = t.reports.getHtml().getDestination()
+             dest.mkdirs()
+             args.add(dest.getAbsolutePath())
         }
         return args
     }


### PR DESCRIPTION
The getHtml() is always a DirectoryReport, so instead of worrying about the entry point, we should be just using getDestination to get the appropriate directory and passing that to scalatest runner. This means we no longer get directories named index.html

Also, create the target directory before running the scalatest runner. Scalatest was crashing because the target directory was not present.

fixes #1 
