### PR TITLE
ability to disable color output based on gradle console setting

### DIFF
--- a/src/main/groovy/com/github/maiflai/ScalaTestAction.groovy
+++ b/src/main/groovy/com/github/maiflai/ScalaTestAction.groovy
@@ -66,7 +66,11 @@ class ScalaTestAction implements Action<Test> {
     private static Iterable<String> getArgs(Test t) {
         List<String> args = new ArrayList<String>()
         // this represents similar behaviour to the existing JUnit test action
-        args.add('-oID')
+        if (t.getProject().getGradle().getStartParameter().isColorOutput()) {
+            args.add('-oID')
+        } else {
+            args.add('-oIDW')
+        }
         if (t.maxParallelForks == 0) {
             args.add('-PS')
         } else {

--- a/src/test/groovy/com/github/maiflai/ScalaTestActionTest.groovy
+++ b/src/test/groovy/com/github/maiflai/ScalaTestActionTest.groovy
@@ -32,6 +32,20 @@ class ScalaTestActionTest {
     }
 
     @Test
+    public void colorOutputIsDisabled() {
+        Task test = testTask()
+        test.getProject().getGradle().startParameter.setColorOutput(false)
+        assertThat(commandLine(test), hasItem("-oIDW".toString()))
+    }
+
+    @Test
+    public void colorOutputIsEnabled() {
+        Task test = testTask()
+        test.getProject().getGradle().startParameter.setColorOutput(true)
+        assertThat(commandLine(test), hasItem("-oID".toString()))
+    }
+
+    @Test
     public void maxHeapSizeIsAdded() throws Exception {
         Task test = testTask()
         String size = '123m'


### PR DESCRIPTION
Hello,

This change allows translating the Gradle's --no-color option (or --console plain) into the scalatest color disable option.
Current behaviour is that the plugin ignores Gradle setting and does not expose ability to individually disable it, which in case of using Gradle with tools that only allow plain console (like Intellij terminal on Windows or Jenkins standard console) will produce obfuscated text.