### PR TITLE
Gradle 4.5 compatibility

### DIFF
--- a/src/main/groovy/com/github/maiflai/BackwardsCompatibleJavaExecActionFactory.groovy
+++ b/src/main/groovy/com/github/maiflai/BackwardsCompatibleJavaExecActionFactory.groovy
@@ -1,0 +1,22 @@
+package com.github.maiflai
+
+import groovy.transform.Immutable
+import org.gradle.api.internal.file.FileResolver
+import org.gradle.process.internal.DefaultExecActionFactory
+import org.gradle.process.internal.DefaultJavaExecAction
+import org.gradle.process.internal.JavaExecAction
+import org.gradle.util.GradleVersion
+
+@Immutable
+class BackwardsCompatibleJavaExecActionFactory {
+    String gradleVersion
+
+    JavaExecAction create(FileResolver fileResolver) {
+        boolean hasExecFactory = GradleVersion.version(gradleVersion) > GradleVersion.version("4.4.1")
+        if (hasExecFactory) {
+            new DefaultExecActionFactory(fileResolver).newJavaExecAction()
+        } else {
+            new DefaultJavaExecAction(fileResolver)
+        }
+    }
+}

--- a/src/main/groovy/com/github/maiflai/ScalaTestAction.groovy
+++ b/src/main/groovy/com/github/maiflai/ScalaTestAction.groovy
@@ -1,5 +1,6 @@
 package com.github.maiflai
 
+import groovy.transform.Immutable
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.internal.file.FileResolver
@@ -10,7 +11,6 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.api.tasks.util.PatternSet
 import org.gradle.internal.UncheckedException
-import org.gradle.process.internal.DefaultJavaExecAction
 import org.gradle.process.internal.JavaExecAction
 
 /**
@@ -19,15 +19,17 @@ import org.gradle.process.internal.JavaExecAction
  * <p>Classpath, JVM Args and System Properties are propagated.</p>
  * <p>Tests are launched against the testClassesDir.</p>
  */
+@Immutable
 class ScalaTestAction implements Action<Test> {
 
     static String TAGS = 'tags'
     static String SUITES = '_suites'
     static String CONFIG = '_config'
+    BackwardsCompatibleJavaExecActionFactory factory
 
     @Override
     void execute(Test t) {
-        def result = makeAction(t).execute()
+        def result = makeAction(t, factory).execute()
         if (result.exitValue != 0){
             handleTestFailures(t)
         }
@@ -61,9 +63,9 @@ class ScalaTestAction implements Action<Test> {
     }
 
 
-    static JavaExecAction makeAction(Test t) {
+    static JavaExecAction makeAction(Test t, BackwardsCompatibleJavaExecActionFactory factory) {
         FileResolver fileResolver = t.getServices().get(FileResolver.class)
-        JavaExecAction javaExecHandleBuilder = new DefaultJavaExecAction(fileResolver)
+        JavaExecAction javaExecHandleBuilder = factory.create(fileResolver)
         t.copyTo(javaExecHandleBuilder)
         javaExecHandleBuilder.setMain('org.scalatest.tools.Runner')
         javaExecHandleBuilder.setClasspath(t.getClasspath())

--- a/src/main/groovy/com/github/maiflai/ScalaTestPlugin.groovy
+++ b/src/main/groovy/com/github/maiflai/ScalaTestPlugin.groovy
@@ -23,7 +23,6 @@ class ScalaTestPlugin implements Plugin<Project> {
     @Override
     void apply(Project t) {
         if (!t.plugins.hasPlugin(ScalaTestPlugin)) {
-            t.plugins.add(this)
             t.plugins.apply(JavaPlugin)
             t.plugins.apply(ScalaPlugin)
             switch (getMode(t)) {

--- a/src/test/groovy/com/github/maiflai/ScalaTestActionTest.groovy
+++ b/src/test/groovy/com/github/maiflai/ScalaTestActionTest.groovy
@@ -11,7 +11,6 @@ import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
 import org.junit.Test
-import org.junit.runners.Parameterized
 
 import static com.github.maiflai.ScalaTestAction.other
 import static org.hamcrest.CoreMatchers.*
@@ -20,6 +19,7 @@ import static org.hamcrest.core.Is.is
 import static org.junit.Assert.assertThat
 
 class ScalaTestActionTest {
+    static FACTORY = new BackwardsCompatibleJavaExecActionFactory(ProjectBuilder.builder().build().gradle.gradleVersion)
 
     private static Project testProject() {
         Project project = ProjectBuilder.builder().build()
@@ -32,7 +32,7 @@ class ScalaTestActionTest {
     }
 
     private static List<String> commandLine(org.gradle.api.tasks.testing.Test task) {
-        JavaExecAction action = ScalaTestAction.makeAction(task)
+        JavaExecAction action = ScalaTestAction.makeAction(task, FACTORY)
         action.getCommandLine()
     }
 
@@ -52,7 +52,7 @@ class ScalaTestActionTest {
     }
 
     private static Map<String, Object> environment(org.gradle.api.tasks.testing.Test task) {
-        JavaExecAction action = ScalaTestAction.makeAction(task)
+        JavaExecAction action = ScalaTestAction.makeAction(task, FACTORY)
         action.getEnvironment()
     }
 
@@ -60,7 +60,7 @@ class ScalaTestActionTest {
     void workingDirectoryIsHonoured() throws Exception {
         Task test = testTask()
         test.workingDir = '/tmp'
-        JavaExecAction action = ScalaTestAction.makeAction(test)
+        JavaExecAction action = ScalaTestAction.makeAction(test, FACTORY)
         assertThat(action.workingDir, equalTo(new File('/tmp')))
     }
 


### PR DESCRIPTION
Applying 'com.github.maiflai.scalatest' fails on Gradle 4.5-rc-1 with the following stack trace:

```
Caused by: java.lang.UnsupportedOperationException
        at org.gradle.api.internal.plugins.DefaultPluginContainer.add(DefaultPluginContainer.java:55)
        at org.gradle.api.plugins.PluginCollection$add.call(Unknown Source)
        at com.github.maiflai.ScalaTestPlugin.apply(ScalaTestPlugin.groovy:26)
        at com.github.maiflai.ScalaTestPlugin.apply(ScalaTestPlugin.groovy)
```

This change removes the call to add itself to `project.plugins`, which gradle will be managing anyway. See https://github.com/gradle/gradle/commit/4c33f1d954b5900ab9a1587f0e787dfaca0a9c16 for the relevant change.

The `DefaultJavaExecAction` constructor has also changed (https://github.com/gradle/gradle/commit/2bafa9609490a29020eeeee4fe0c9a176afd8adc). Added a backwards-compatible way to create the `DefaultJavaExecAction`.