### PR TITLE
Gradle 4.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,5 +2,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
-distributionSha256Sum=6ac2f8f9302f50241bf14cc5f4a3d88504ad20e61bb98c5fd048f7723b61397e
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionSha256Sum=9af7345c199f1731c187c96d3fe3d31f5405192a42046bafa71d846c3d9adacb


### PR DESCRIPTION
* Upgraded to Gradle 4.6 ([release notes](https://docs.gradle.org/4.6/release-notes.html))
* Added .gitignore to ignore contents of `.gradle/` and `build/` directories