### PR TITLE
Add knownImmutableClasses to ScalaTestAction to avoid breaking change with groovy 2.5

### DIFF
--- a/src/main/groovy/com/github/maiflai/ScalaTestAction.groovy
+++ b/src/main/groovy/com/github/maiflai/ScalaTestAction.groovy
@@ -19,7 +19,7 @@ import org.gradle.process.internal.JavaExecAction
  * <p>Classpath, JVM Args and System Properties are propagated.</p>
  * <p>Tests are launched against the testClassesDir.</p>
  */
-@Immutable
+@Immutable(knownImmutableClasses = [BackwardsCompatibleJavaExecActionFactory])
 class ScalaTestAction implements Action<Test> {
 
     static String TAGS = 'tags'


### PR DESCRIPTION
Gradle 5 is moving to groovy 2.5 which introduces the following error:

```
Caused by: java.lang.RuntimeException: Unsupported type (com.github.maiflai.BackwardsCompatibleJavaExecActionFactory) found for field 'factory' while constructing immutable class com.github.maiflai.ScalaTestAction.
Immutable classes only support properties with effectively immutable types including:
- Strings, primitive types, wrapper types, Class, BigInteger and BigDecimal, enums
- classes annotated with @KnownImmutable and known immutables (java.awt.Color, java.net.URI)
- Cloneable classes, collections, maps and arrays, and other classes with special handling
  (java.util.Date and various java.time.* classes and interfaces)
```

