### PR TITLE
spanScaleFactor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ test {
 }
 ```
 
+Span Scale Factor
+----------------
+```groovy
+test {
+    spanScaleFactor 10.0
+}
+```
+
 Other Frameworks
 ----------------
 The default behaviour is to replace all `Test` tasks with a scalatest implementation.

--- a/src/main/groovy/com/github/maiflai/ScalaTestAction.groovy
+++ b/src/main/groovy/com/github/maiflai/ScalaTestAction.groovy
@@ -28,6 +28,7 @@ class ScalaTestAction implements Action<Test> {
     static String SUITES = '_suites'
     static String CONFIG = '_config'
     static String REPORTERS = '_reporters'
+    static String SPAN_SCALE_FACTOR = '_spanScaleFactor'
 
     @Override
     void execute(Test t) {
@@ -195,6 +196,11 @@ class ScalaTestAction implements Action<Test> {
         reporters?.toSet()?.each {
             args.add('-C')
             args.add(it)
+        }
+        def spanScaleFactor = t.extensions.findByName(SPAN_SCALE_FACTOR) as List<Float>
+        spanScaleFactor?.toSet()?.each {
+            args.add('-F')
+            args.add(it.toString())
         }
         assert args.every { it.length() > 0 }
         return args

--- a/src/main/groovy/com/github/maiflai/ScalaTestPlugin.groovy
+++ b/src/main/groovy/com/github/maiflai/ScalaTestPlugin.groovy
@@ -75,6 +75,10 @@ class ScalaTestPlugin implements Plugin<Project> {
         test.extensions.add(ScalaTestAction.REPORTERS, reporters)
         test.extensions.add("reporter", { String name -> reporters.add(name) })
         test.extensions.add("reporters", { String... name -> reporters.addAll(name) })
+        List<Float> spanScaleFactor = []
+        test.extensions.add(ScalaTestAction.SPAN_SCALE_FACTOR, spanScaleFactor)
+        test.extensions.add("spanScaleFactor", { Float factor -> spanScaleFactor.add(factor) })
+
         test.testLogging.events = TestLogEvent.values() as Set
     }
 

--- a/src/test/groovy/com/github/maiflai/ScalaTestActionTest.groovy
+++ b/src/test/groovy/com/github/maiflai/ScalaTestActionTest.groovy
@@ -315,4 +315,12 @@ class ScalaTestActionTest {
         def args = commandLine(test)
         assertThat(args, hasOption('-R', '/serviceuitest-1.1beta4.jar /myjini /target/class\\ files'))
     }
+
+    @Test
+    void spanScaleFactor() throws Exception {
+        Task test = testTask()
+        test.spanScaleFactor 10.5
+        def args = commandLine(test)
+        assertThat(args, hasOption('-F', '10.5'))
+    }
 }


### PR DESCRIPTION
Add support of spanScaleFactor (`-F`).

My project is still using gradle 6.x, so it would be happy if this change is also back-ported into 0.30 and release it as 0.30.x. 

Thanks.
