### PR TITLE
replace AdoptOpenJDK with Temurin JDK

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle


### PR DESCRIPTION

AdoptOpenJDK is obsolete. It is not longer supported.

Use Temurin JDK instead.

https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/


